### PR TITLE
feat: support line breaks in texts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -261,12 +261,22 @@ export class MarkdownRenderer {
   }
 
   private handleText(text: MDAST.Text) {
-    const raw = text.value.replace(/[\s\r\n]+/g, " ");
-    this.doc.text(raw, {
-      continued: true,
-      link: this.link,
-      underline: !!this.link,
-      strike: this.strike,
-    });
+    const lines = text.value.split(/[\r\n]+/g);
+
+    let index = 0;
+    for (const line of lines) {
+      /*
+        If the line is empty, we still want to render
+        a space for pdfkit to correctly handle line breaks
+      */
+      this.doc.text(line || ' ', {
+        continued: lines.length === 1 || index === lines.length - 1,
+        link: this.link,
+        underline: !!this.link,
+        strike: this.strike,
+      });
+
+      index++;
+    }
   }
 }


### PR DESCRIPTION
Hi Hanno,

I noticed that line breaks (\n) was replaced with " " in strings before rendering texts, meaning line breaks within paragraphs and in list items was lost.

I made some changes and it seems to work for my use case. But maybe you know of other reasons \n was removed from strings?

Generated pdf with working line breaks in paragraph and list items:
<img width="875" alt="image" src="https://github.com/user-attachments/assets/977054b7-136e-48bf-9970-993d47ca2e94">


/ Karl