### PR TITLE
Fix listitem pagebreak issue

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -217,9 +217,10 @@ export class MarkdownRenderer {
   private handleListItem(item: MDAST.ListItem) {
     const indent =
       this.doc.page.margins.left +
-      (this.listIndent - 1 + this.settings.listItemIndentOffset) * this.settings.listItemIndent;
-    this.doc.circle(indent + 1, this.doc.y + 4, 1).fill("black");
+      (this.listIndent - 1) * this.settings.listItemIndent;
     this.doc.x = indent + this.settings.listItemIndent;
+    this.doc.text("", {continued: true}); // Make pdfkit page break before adding the list item, if needed
+    this.doc.circle(indent + 1, this.doc.y + 4, 1).fill("black");
     for (const child of item.children) this.handleChild(child);
     this.doc.x = this.doc.page.margins.left;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -217,7 +217,7 @@ export class MarkdownRenderer {
   private handleListItem(item: MDAST.ListItem) {
     const indent =
       this.doc.page.margins.left +
-      (this.listIndent - 1) * this.settings.listItemIndent;
+      (this.listIndent - 1 + this.settings.listItemIndentOffset) * this.settings.listItemIndent;
     this.doc.x = indent + this.settings.listItemIndent;
     this.doc.text("", {continued: true}); // Make pdfkit page break before adding the list item, if needed
     this.doc.circle(indent + 1, this.doc.y + 4, 1).fill("black");


### PR DESCRIPTION
Hi,

Found an issue where list item bullets was drawn on the wrong page, if the list item text triggered a page break. 

I added a empty text to make pdfkit line break before adding the bullet, if needed.

Before fix:
<img width="616" alt="Screenshot 2024-08-29 at 12 22 55" src="https://github.com/user-attachments/assets/12669d3b-30e4-423c-871f-d3f3015911c4">

After fix:
<img width="402" alt="Screenshot 2024-08-29 at 12 23 24" src="https://github.com/user-attachments/assets/b4d4fa75-3340-42b3-9072-dc770d6f98f9">

/ Karl