### PR TITLE
Align the default font sizes of headers to be the same as WHATWG specifies for HTML.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -67,7 +67,18 @@ export class MarkdownRenderer {
     boldFont: "Helvetica-Bold",
     italicFont: "Helvetica-Oblique",
     headerFontName: () => "Helvetica-Bold",
-    headerFontSize: headerLookup,
+    headerFontSize: (depth: number) => {
+      const size = this.settings.fontSize;
+      switch (depth) {
+        case 1: return 2 * size;
+        case 2: return 1.5 * size;
+        case 3: return 1.17 * size;
+        case 4: return 1 * size;
+        case 5: return 0.83 * size;
+        case 6: return 0.67 * size;
+        default: return 1 * size;
+      }
+    },
     headerGapBefore: () => 12,
     headerGapAfter: () => 8,
     fontSize: 10,

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,18 @@ export interface PdfkitMarkdownSettings {
   throwOnUnsupported: boolean;
 }
 
+function headerLookup(h: number) {
+  switch (h) {
+    case 1: return 32;
+    case 2: return 24;
+    case 3: return 18.72;
+    case 4: return 16;
+    case 5: return 13.28;
+    case 6: return 10.72;
+    default: return 16;
+  }
+}
+
 export class MarkdownRenderer {
   private settings: PdfkitMarkdownSettings = {
     blockQuoteIndent: 7,
@@ -55,7 +67,7 @@ export class MarkdownRenderer {
     boldFont: "Helvetica-Bold",
     italicFont: "Helvetica-Oblique",
     headerFontName: () => "Helvetica-Bold",
-    headerFontSize: (h) => 20 - h * 1.5,
+    headerFontSize: headerLookup,
     headerGapBefore: () => 12,
     headerGapAfter: () => 8,
     fontSize: 10,

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,18 +40,6 @@ export interface PdfkitMarkdownSettings {
   throwOnUnsupported: boolean;
 }
 
-function headerLookup(h: number) {
-  switch (h) {
-    case 1: return 32;
-    case 2: return 24;
-    case 3: return 18.72;
-    case 4: return 16;
-    case 5: return 13.28;
-    case 6: return 10.72;
-    default: return 16;
-  }
-}
-
 export class MarkdownRenderer {
   private settings: PdfkitMarkdownSettings = {
     blockQuoteIndent: 7,

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,15 +56,14 @@ export class MarkdownRenderer {
     italicFont: "Helvetica-Oblique",
     headerFontName: () => "Helvetica-Bold",
     headerFontSize: (depth: number) => {
-      const size = this.settings.fontSize;
       switch (depth) {
-        case 1: return 2 * size;
-        case 2: return 1.5 * size;
-        case 3: return 1.17 * size;
-        case 4: return 1 * size;
-        case 5: return 0.83 * size;
-        case 6: return 0.67 * size;
-        default: return 1 * size;
+        case 1: return 2 * this.settings.fontSize;
+        case 2: return 1.5 * this.settings.fontSize;
+        case 3: return 1.17 * this.settings.fontSize;
+        case 4: return 1 * this.settings.fontSize;
+        case 5: return 0.83 * this.settings.fontSize;
+        case 6: return 0.67 * this.settings.fontSize;
+        default: return this.settings.fontSize;
       }
     },
     headerGapBefore: () => 12,


### PR DESCRIPTION
Currently, pdfkit-markdown's simple function for determining the font size of a heading does not align with what the [WHATWG specifies](https://html.spec.whatwg.org/multipage/rendering.html#sections-and-headings) for the default sizing of a header.

This could result in noticeable rendering differences when reading the same document rendered to HTML and PDF.

This pull request aligns the default header font size function to the standard.