### PR TITLE
Add an option to create PDF outlines (chapter bookmarks) based on header structure.

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "peerDependencies": {
     "mdast": ">= 3.0.0 < 4.0.0",
-    "pdfkit": "^0.17.2"
+    "pdfkit": ">= 0.12.0 < 0.16.0"
   },
   "optionalDependencies": {
     "mdast": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "devDependencies": {
     "@types/mdast": "^4.0.4",
-    "@types/pdfkit": "^0.13.4",
+    "@types/pdfkit": "^0.17.4",
     "mdast": "^3.0.0",
     "pdfkit": "^0.15.0",
     "remark-parse": "^11.0.0",
@@ -36,7 +36,7 @@
   },
   "peerDependencies": {
     "mdast": ">= 3.0.0 < 4.0.0",
-    "pdfkit": ">= 0.12.0 < 0.16.0"
+    "pdfkit": "^0.17.2"
   },
   "optionalDependencies": {
     "mdast": "^3.0.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,8 +36,8 @@ export interface PdfkitMarkdownSettings {
   headerGapBefore: (depth: number) => number;
   /** Function to determine gap size after a header by depth */
   headerGapAfter: (depth: number) => number;
-  /** Add outlines (bookmarks) based on the header */
-  displayHeaderOutlines: boolean;
+  /** Add outlines (bookmarks) based on the header depth */
+  headerOutlines: (depth:number) => boolean;
   /** Throw error on unsupported markdown feature, otherwise silently ignored */
   throwOnUnsupported: boolean;
 }
@@ -60,7 +60,7 @@ export class MarkdownRenderer {
     headerFontSize: (h) => 20 - h * 1.5,
     headerGapBefore: () => 12,
     headerGapAfter: () => 8,
-    displayHeaderOutlines: true,
+    headerOutlines: () => true,
     fontSize: 10,
     throwOnUnsupported: false,
   };
@@ -185,7 +185,7 @@ export class MarkdownRenderer {
   }
 
   private handleHeading(heading: MDAST.Heading) {
-    if (this.settings.displayHeaderOutlines) {
+    if (this.settings.headerOutlines(heading.depth)) {
       const text = heading.children.find(child => child.type == "text")?.value;
       if (text) {
         this.outlineStack.splice(heading.depth);

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,8 @@ export interface PdfkitMarkdownSettings {
   headerGapBefore: (depth: number) => number;
   /** Function to determine gap size after a header by depth */
   headerGapAfter: (depth: number) => number;
+  /** Add outlines (bookmarks) based on the header */
+  displayHeaderOutlines: boolean;
   /** Throw error on unsupported markdown feature, otherwise silently ignored */
   throwOnUnsupported: boolean;
 }
@@ -58,6 +60,7 @@ export class MarkdownRenderer {
     headerFontSize: (h) => 20 - h * 1.5,
     headerGapBefore: () => 12,
     headerGapAfter: () => 8,
+    displayHeaderOutlines: true,
     fontSize: 10,
     throwOnUnsupported: false,
   };
@@ -74,10 +77,12 @@ export class MarkdownRenderer {
   render(tree: MDAST.Root) {
     this.doc.fontSize(this.settings.fontSize);
     this.updateFont();
+    this.outlineStack = [ this.doc.outline ];
 
     for (const c of tree.children) this.handleChild(c);
   }
 
+  private outlineStack: PDFKit.PDFOutline[] = [];
   private listIndent = 0;
   private bold = false;
   private italic = false;
@@ -182,6 +187,13 @@ export class MarkdownRenderer {
   }
 
   private handleHeading(heading: MDAST.Heading) {
+    if (this.settings.displayHeaderOutlines) {
+      const text = heading.children.find(child => child.type == "text")?.value;
+      if (text) {
+        this.outlineStack.splice(heading.depth);
+        this.outlineStack.push(this.outlineStack[this.outlineStack.length - 1].addItem(text, { expanded: true }));
+      }
+    }
     this.doc.y += this.settings.headerGapBefore(heading.depth);
     this.doc.font(this.settings.headerFontName(heading.depth));
     this.doc.fontSize(this.settings.headerFontSize(heading.depth));

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,6 +82,7 @@ export class MarkdownRenderer {
     for (const c of tree.children) this.handleChild(c);
   }
 
+  /** Used to keep track of the context for bookmark purposes */
   private outlineStack: PDFKit.PDFOutline[] = [];
   private listIndent = 0;
   private bold = false;


### PR DESCRIPTION
It can be helpful for some markdown documents to create chapter bookmarks (in PDF parlance, an outline) based on the headers put into the document. This PR aims to add this functionality to pdfkit-markdown.

This would involve updating to a version 0.17 of pdfkit and adding some coordinating logic.

Before:
![Screenshot_20251223_210801](https://github.com/user-attachments/assets/da0bae91-1175-47bd-94ef-020811c2c30c)
After:
![Screenshot_20251223_210829](https://github.com/user-attachments/assets/22c5afcb-e494-4b39-a8d0-ca21753c6f84)
