### PR TITLE
Remove duplicate branch for links in switch statement.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -93,9 +93,6 @@ export class MarkdownRenderer {
       case "heading":
         this.handleHeading(child);
         break;
-      case "link":
-        this.handleLink(child);
-        break;
       case "paragraph":
         this.handleParagraph(child);
         break;


### PR DESCRIPTION
This PR removes one of two identical branches in the `handleChild` function's switch statement that calls the `handleLink` function when encountering a link.